### PR TITLE
Local: Make pre-commit run from local environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,25 @@ repos:
         name: black
         entry: black
         language: system
-        types: [python]
+        types_or: [python, pyi]
+        require_serial: true
     -   id: flake8
         name: flake8
         entry: flake8
         language: system
         types: [python]
+        require_serial: true
     -   id: mypy
         name: mypy
         entry: mypy
+        args: ["--ignore-missing-imports", "--scripts-are-modules"]
         language: system
-        types: [python]
+        types_or: [python, pyi]
+        require_serial: true
     -   id: isort
         name: isort
         entry: isort
         args: ["--profile", "black"]
         language: system
-        types: [python]
+        types_or: [cython, pyi, python]
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,24 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 23.10.1
+-   repo: local
     hooks:
-    - id: black
-      language_version: python3
--   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-    - id: flake8
-      additional_dependencies: [Flake8-pyproject]
--   repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v1.6.1
-    hooks:
-    - id: mypy
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-    - id: isort
-      args: ["--profile", "black"]
-
+    -   id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]
+    -   id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+    -   id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+    -   id: isort
+        name: isort
+        entry: isort
+        args: ["--profile", "black"]
+        language: system
+        types: [python]


### PR DESCRIPTION


## Issue
Pre-commit typically creates its own environments based on the versions provided in pre-commit yaml file.
This means that the packages installed from requirement-dev.txt are not actually used.

This approach also forces us to duplicate package versioning in both pre-commit's yaml and requirements-dev.txt.
Since dependabot does not support pre-commit configuration files, the duplication entails a considerable overhead.



## Description of work

This commit modifies pre-commit's config to use the local environment instead of spwaning one environment per hook.

## Checklist

- [x] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
