### PR TITLE
Fix precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,20 +5,25 @@ repos:
         name: black
         entry: black
         language: system
-        types: [python]
+        types_or: [python, pyi]
+        require_serial: true
     -   id: flake8
         name: flake8
         entry: flake8
         language: system
         types: [python]
+        require_serial: true
     -   id: mypy
         name: mypy
         entry: mypy
+        args: ["--ignore-missing-imports", "--scripts-are-modules"]
         language: system
-        types: [python]
+        types_or: [python, pyi]
+        require_serial: true
     -   id: isort
         name: isort
         entry: isort
         args: ["--profile", "black"]
         language: system
-        types: [python]
+        types_or: [cython, pyi, python]
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,24 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 23.10.1
+-   repo: local
     hooks:
-    - id: black
-      language_version: python3
--   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-    - id: flake8
-      additional_dependencies: [Flake8-pyproject]
--   repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v1.6.1
-    hooks:
-    - id: mypy
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-    - id: isort
-      args: ["--profile", "black"]
-
+    -   id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]
+    -   id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+    -   id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+    -   id: isort
+        name: isort
+        entry: isort
+        args: ["--profile", "black"]
+        language: system
+        types: [python]

--- a/forwarder/update_handlers/fake_update_handler.py
+++ b/forwarder/update_handlers/fake_update_handler.py
@@ -3,6 +3,7 @@ from random import randint
 from typing import List
 
 import numpy as np
+from numpy.typing import NDArray
 from p4p.nt import NTScalar
 
 from forwarder.application_logger import get_logger
@@ -34,7 +35,7 @@ class FakeUpdateHandler:
     def _timer_callback(self):
         if self._schema == "tdct":
             # tdct needs a 1D array as data to send
-            data = np.array([randint(0, 100)]).astype(np.int32)
+            data: NDArray[np.int32] = np.array([randint(0, 100)]).astype(np.int32)
             response = NTScalar("ai").wrap(data)
         else:
             # Otherwise 0D (scalar) is fine

--- a/forwarder/update_handlers/tdct_serialiser.py
+++ b/forwarder/update_handlers/tdct_serialiser.py
@@ -3,6 +3,7 @@ from typing import Tuple, Union
 import numpy as np
 import p4p
 from caproto import Message as CA_Message
+from numpy.typing import NDArray
 from streaming_data_types.timestamps_tdct import serialise_tdct
 
 from forwarder.epics_to_serialisable_types import (
@@ -87,5 +88,5 @@ class tdct_PVASerialiser(PVASerialiser):
         except AttributeError:
             pass
         data_type = numpy_type_from_p4p_type[update.type()["value"][-1]]
-        value_arr = np.squeeze(np.array(update.value)).astype(data_type)
+        value_arr: NDArray = np.squeeze(np.array(update.value)).astype(data_type)
         return self._serialise(value_arr, origin_time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,9 @@ commands =
 """
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.8
 check_untyped_defs = true
+plugins = ["numpy.typing.mypy_plugin"]
 
 [[tool.mypy.overrides]]
 module = "confluent_kafka.*"
@@ -132,4 +133,3 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "attr.*"
 ignore_errors = true
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ p4p == 4.1.11
 confluent_kafka == 2.3.0
 graypy == 2.1.0
 graphyte == 1.7.1
-numpy >= 1.19
+numpy >= 1.21
 ConfigArgParse == 1.7
 ess-streaming-data-types == 0.23.1
 tomli==2.0.1

--- a/tests/update_handlers/ep00_serialiser_test.py
+++ b/tests/update_handlers/ep00_serialiser_test.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+from numpy.typing import NDArray
 from p4p.client.thread import Disconnected
 from p4p.nt import NTScalar
 from streaming_data_types.epics_connection_info_ep00 import EventType, deserialise_ep00
@@ -29,7 +30,7 @@ def test_serialise_pva_start():
 
 
 def test_serialise_pva_value():
-    test_data = np.array([-3, -2, -1]).astype(np.int32)
+    test_data: NDArray = np.array([-3, -2, -1]).astype(np.int32)
     reference_timestamp = 10
     update = NTScalar("ai").wrap(test_data)
     update.timeStamp.secondsPastEpoch = 0

--- a/tests/update_handlers/ep01_serialiser_test.py
+++ b/tests/update_handlers/ep01_serialiser_test.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 import p4p.client.thread
 import pytest
+from numpy.typing import NDArray
 from p4p.client.thread import Cancelled, Disconnected, Finished, RemoteError
 from p4p.nt import NTScalar
 from streaming_data_types.epics_connection_ep01 import ConnectionInfo, deserialise_ep01
@@ -24,7 +25,7 @@ def _test_serialise_start(pv_name, serialiser):
 
 
 def _create_value_update(reference_timestamp):
-    test_data = np.array([-3, -2, -1]).astype(np.int32)
+    test_data: NDArray = np.array([-3, -2, -1]).astype(np.int32)
     update = NTScalar("ai").wrap(test_data)
     update.timeStamp.secondsPastEpoch = 0
     update.timeStamp.nanoseconds = reference_timestamp

--- a/tests/update_handlers/nttable_se00_test.py
+++ b/tests/update_handlers/nttable_se00_test.py
@@ -2,6 +2,7 @@ from time import time
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 from p4p import Value
 from p4p.nt import NTTable
 from streaming_data_types.alarm_al00 import Severity as al00_Severity
@@ -20,8 +21,8 @@ pytestmark = [
 
 
 def test_serialise_nttable_se00():
-    values = np.arange(-50, 50, 11, dtype=np.float32)
-    timestamps = np.arange(50, 150, dtype=np.uint64)
+    values: NDArray = np.arange(-50, 50, 11, dtype=np.float32)
+    timestamps: NDArray = np.arange(50, 150, dtype=np.uint64)
     table = NTTable.buildType(
         columns=[
             ("column0", "af"),
@@ -52,7 +53,7 @@ def test_serialise_nttable_se00():
 
 def test_update_handler_publishes_se00_alarm_update(context, producer, pv_source_name):
     pv_timestamp_s = time()  # seconds from unix epoch
-    values = np.arange(-50, 50, 11, dtype=np.float32)
+    values: NDArray = np.arange(-50, 50, 11, dtype=np.float32)
     timestamps = np.repeat(int(time()), 100)
     alarm_status = 4  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
     alarm_severity = 1  # al00_Severity.MINOR

--- a/tests/update_handlers/nttable_senv_test.py
+++ b/tests/update_handlers/nttable_senv_test.py
@@ -3,6 +3,7 @@ from time import time
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 from p4p import Value
 from p4p.nt import NTTable
 from streaming_data_types.alarm_al00 import Severity as al00_Severity
@@ -21,8 +22,8 @@ pytestmark = [
 
 
 def test_serialise_nttable():
-    values = np.arange(-50, 50, dtype=np.int16)
-    timestamps = np.arange(50, 150, dtype=np.uint64)
+    values: NDArray = np.arange(-50, 50, dtype=np.int16)
+    timestamps: NDArray = np.arange(50, 150, dtype=np.uint64)
     first_timestamp = timestamps[0] / 1e9
 
     table = NTTable.buildType(
@@ -58,7 +59,7 @@ def test_serialise_nttable():
 
 def test_update_handler_publishes_senv_alarm_update(context, producer, pv_source_name):
     pv_timestamp_s = time()  # seconds from unix epoch
-    values = np.arange(-50, 50, 11, dtype=np.float32)
+    values: NDArray = np.arange(-50, 50, 11, dtype=np.float32)
     timestamps = np.repeat(int(time()), 100)
     alarm_status = 4  # Indicates RECORD alarm, we map the alarm message to a specific alarm status to forward
     alarm_severity = 1  # al00_Severity.MINOR

--- a/tests/update_handlers/tdct_test.py
+++ b/tests/update_handlers/tdct_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 from p4p.nt import NTScalar
 from streaming_data_types.timestamps_tdct import deserialise_tdct
 
@@ -13,7 +14,7 @@ pytestmark = [pytest.mark.epics_protocol(EpicsProtocol.PVA), pytest.mark.schema(
 
 
 def test_tdct_serialiser_handles_positive_relative_timestamps():
-    input_relative_timestamps = np.array([10, 11, 12]).astype(np.int32)
+    input_relative_timestamps: NDArray = np.array([10, 11, 12]).astype(np.int32)
     # This is the timestamp of the PV update
     reference_timestamp = 10
     serialiser = tdct_PVASerialiser("tst_source")
@@ -31,7 +32,7 @@ def test_tdct_serialiser_handles_positive_relative_timestamps():
 
 
 def test_tdct_serialiser_handles_negative_relative_timestamps():
-    input_relative_timestamps = np.array([-3, -2, -1]).astype(np.int32)
+    input_relative_timestamps: NDArray = np.array([-3, -2, -1]).astype(np.int32)
     # This is the timestamp of the PV update
     reference_timestamp = 10
     serialiser = tdct_PVASerialiser("tst_source")
@@ -68,7 +69,7 @@ def test_tdct_publisher_publishes_successfully_when_there_is_only_a_single_chopp
 
 
 def test_tdct_serialiser_handles_empty_array():
-    input_relative_timestamps = np.array([]).astype(np.int32)
+    input_relative_timestamps: NDArray = np.array([]).astype(np.int32)
     # This is the timestamp of the PV update
     reference_timestamp = 10
     serialiser = tdct_PVASerialiser("tst_source")


### PR DESCRIPTION
## Issue

    
    Numpy offers a numpy plugin numpy.typing.mypy_plugin
    We load it in pyproject.toml but it seems to not work when the plugin
    name has quotes. Without quotes, the TOML file is invalid for tomllib
    and breaks black and flake8.
    


## Description of work

    We add the numpy mypy plugin with quotes, hoping that mypy will eventually
    use it correctly.
    We also add a few numpy types manually to silence mypy warning.


## Checklist

- [x] Pre-commit hooks have been run (see https://github.com/ess-dmsc/forwarder#developer-information)
- [ ] Changes have been documented in `changes.md`
